### PR TITLE
feat: add karate script as a NPM binary to be used as a CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,124 @@
-# @karatelabs/karate
+# @karatelabs/karate <!-- omit in toc -->
+
 Seamlessly use the power of [Karate](https://github.com/karatelabs/karate) from Node / JS projects.
 
-## Usage
-Given this script `test.js`:
+## Table of Contents <!-- omit in toc -->
 
-```js
-#! /usr/bin/env node
-const karate = require('@karatelabs/karate');
-karate.exec();
-```
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Configuration file](#configuration-file)
+  - [As a library](#as-a-library)
+    - [configure(options)](#configureoptions)
+    - [exec(args)](#execargs)
+  - [As a wrapper CLI](#as-a-wrapper-cli)
+    - [Wrapper options](#wrapper-options)
+    - [Wrapper arguments](#wrapper-arguments)
+    - [Examples](#examples)
+    - [CLI Reference](#cli-reference)
+- [Known Issues](#known-issues)
 
-And in `package.json` (use the latest version from [npm](https://www.npmjs.com/package/@karatelabs/karate)):
+## Installation
 
-```json
-{
-  "scripts": {
-    "test": "node test.js"
-  },
-  "devDependencies": {
-    "@karatelabs/karate": "^0.2.2"
-  }
-}
-```
+`npm i @karatelabs/karate --save`
+
+Prefer installing the package globally if you want to use it as a CLI wrapper of `Karate`:
+
+`npm i -g @karatelabs/karate`
 
 When you run `npm install`, [jbang](https://www.jbang.dev/) and other Karate dependencies needed will be installed via [`jbang-npm`](https://github.com/jbangdev/jbang-npm).
 
-And to run a single test:
+## Usage
 
-```
-npm run test karate/httpbin.feature
-```
+### Configuration file
 
-Or to run all tests in a folder:
+Karate will look for a `karate-config.js` file in the current working directory.
 
-```
-npm run test karate
-```
+But if you need to point to a different directory, you can set the configuration directory with `karate.configure` function before calling `karate.exec()`. You can also configure karate via [CLI](as-a-cli) options.
 
-## Known Issues
-Users on Windows have reported [issues](https://github.com/karatelabs/karate-npm/issues/2) such as the `npm install` failing to complete and without any errors shown.
+Example file: [karate-config.js](karate/karate-config.js).
 
-Please do contribute if you can and improve how JavaScript projects can integrate smoothly with Java projects !
-
-As a workaround, please [install JBang manually](https://www.jbang.dev/documentation/guide/latest/installation.html) and re-try the `npm install` step.
-
-## Setting Karate Version
-
-To use a specific version of Karate, just set `karate.version` before calling `karate.exec()`:
+### As a library
 
 ```js
-#! /usr/bin/env node
-const karate = require('@karatelabs/karate');
-karate.version = '1.2.0';
-karate.exec();
+const karate = require('@karatelabs/karate ');
 ```
 
-## CLI Reference
+`karate` is an object exposing the following.
+
+#### configure(options)
+
+Configure the directory where to run tests and the version of the karate executable to run.
+
+- `options` **<Object\>**
+  - `dir` **<String\>** Path to directory used for Karate tests. *Default*: `.` *Required*: `false`
+  - `version` **<String\>** [Karate version](https://github.com/karatelabs/karate/releases) to use. See also [Karate with JBang](https://karatelabs.github.io/karate/karate-netty/#jbang). *Default*: `LATEST` *Required*: `false`
+- Returns: **<undefined\>**
+
+Example:
+
+```js
+karate.configure({ dir: '.', version: '1.2.0' });
+```
+
+#### exec(args)
+
+Execute a Karate command by using the `jbang.exec()` function with the `jbang` executable. All Karate capabilities can be found [here](https://github.com/karatelabs/karate/tree/master/karate-netty#usage).
+
+- `args` **<String\>** Arguments and options to pass to the Karate command. *Default*: None *Required*: `true`
+- Returns: **<undefined\>**
+
+Examples:
+
+```js
+// run a single test
+karate.exec('karate/httpbin.feature');
+
+// run all tests in a folder
+karate.exec('karate/');
+```
+
+### As a wrapper CLI
+
+Package preferably installed globally, you can run in a shell the command named `karate`. This command is a wrapper of the `karate` command run by JBang.
+
+#### Wrapper options
+
+- `--use-dir <path>` Directory to use for Karate tests. *Default*: `.` *Required*: `false`
+- `--use-version <version>` [Karate version](https://github.com/karatelabs/karate/releases) to use. See also [Karate with JBang](https://karatelabs.github.io/karate/karate-netty/#jbang). *Default*: `LATEST` *Required*: `false`
+- `--assist` Show assistance. *Default*: None *Required*: `false`
+- `--debug` Output extra debugging. *Default*: `false` *Required*: `false`
+
+#### Wrapper arguments
+
+- `<args>` Command to be run by `karate`. *Default*: None *Required*: `true`
+
+#### Examples
+
+```shell
+# run a single test
+karate --use-dir . --use-version 1.2.0 --debug karate/httpbin.feature
+
+# run all tests in a folder
+karate karate/
+```
+
+#### CLI Reference
+
 All Karate capabilities can be invoked by the command-line.
 
 The most common needs are to:
 
-* run feature-file(s) or all feature-files in a folder as Karate tests 
-* start an API mock-server
+- run feature-file(s) or all feature-files in a folder as Karate tests
+- start an API mock-server
 
 The complete documentation can be found [here](https://github.com/karatelabs/karate/tree/master/karate-netty#usage).
 
 You can also use the `--help` command-line option to see all the possible options and brief descriptions on the console.
 
-### `karate-config.js`
+## Known Issues
 
-Karate will look for a `karate-config.js` file in the current working directory.
+Users on Windows have reported [issues](https://github.com/karatelabs/karate-npm/issues/2) such as the `npm install` failing to complete and without any errors shown.
 
-But if you need to point to a different directory, you can set `karate.config.dir` before calling `karate.exec()`
+Please do contribute if you can and improve how JavaScript projects can integrate smoothly with Java projects !
 
-```js
-#! /usr/bin/env node
-const karate = require('@karatelabs/karate');
-karate.config.dir = '/users/myname/some/dir';
-karate.exec();
-```
+As a workaround, please [install JBang manually](https://www.jbang.dev/documentation/guide/latest/installation.html) and re-try the `npm install` step.

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,36 @@
+#! /usr/bin/env node
+
+const { Command } = require('commander');
+const { bin, description } = require('../package.json');
+const karate = require('../karate');
+
+const program = new Command();
+
+program.description(description)
+  .name(Object.keys(bin)[0])
+  .helpOption('--assist', 'show assistance\ncheck https://github.com/karatelabs/karate/tree/master/karate-netty#usage for karate usage\nor -h to display all available arguments and options')
+  .showHelpAfterError('(add --assist for additional information)')
+  .showSuggestionAfterError()
+  .allowUnknownOption()
+  .argument('<args>')
+  .option('--use-dir <path>', 'directory to use for Karate tests')
+  .option('--use-version <version>', 'karate version to use, LATEST by default', 'LATEST')
+  .option('--debug', 'output extra debugging', false)
+
+program.parse(process.argv);
+
+const {
+  debug,
+  useDir: dir,
+  useVersion: version,
+} = program.opts();
+
+karate.configure({ dir, version });
+
+if (debug) {
+  console.debug('command options:', program.opts());
+  console.debug('command arguments:', program.args);
+  console.debug(`karate: version ${karate.version}, directory ${karate.config.dir}`);
+}
+
+karate.exec(program.args.join(' '));

--- a/karate.js
+++ b/karate.js
@@ -2,13 +2,22 @@ const jbang = require('@jbangdev/jbang');
 const karate = {};
 karate.version = 'LATEST';
 karate.config = {};
+karate.configure = function ({ dir, version } = {}) {
+	if (dir && dir.constructor === String) {
+		karate.config.dir = dir;
+	}
+
+	if (version && version.constructor === String) {
+		karate.version = version;
+	}
+};
 karate.executable = function () {
 	let prefix = karate.config.dir ? '-Dkarate.config.dir=' + karate.config.dir + ' '  : '';
 	return prefix + 'com.intuit.karate:karate-core:' + karate.version + ':all';
 };
 karate.exec = function (args) {
 	if (!args) {
-		args = process.argv.slice(2).join(' ');
+		args = '';
 	}
 	process.env['KARATE_META'] = 'npm:' + process.env.npm_package_version;
 	jbang.exec(karate.executable() + ' ' + args);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/karatelabs/karate-npm.git"
-  },  
+  },
+  "bin": {
+    "karate": "bin/index.js"
+  },
   "main": "karate.js",
   "scripts": {
     "test": "node test.js",
@@ -15,6 +18,7 @@
   "author": "Peter Thomas",
   "license": "MIT",
   "dependencies": {
-    "@jbangdev/jbang": "^0.1.4"
+    "@jbangdev/jbang": "^0.1.4",
+    "commander": "^9.3.0"
   }
 }


### PR DESCRIPTION
Hi guys, it's me again,

It's soooo cool you brought Karate to the Node ecosystem, thanks a lot!

## Context
Same as for the JBang feature, I'd like to easily install Karate via NPM  and have it globally as a command right after installation. It will be used in our Gitlab CI in a Docker context.

## Problem
The problem I was facing is that I thought I could install your package globally and directly run the `karate` command which was not the case.

## Solution
I'me using the `bin` entry again in the `package.json` to define a command (which is basically running `node` on a file) that will be available globally. So I've added a `bin/index.js` file using `Commander` package to create a CLI which basically is a wrapper of the `karate` command using Jbang executable under the hood. This way at package installation we automatically can run the `karate` command.

I'd like to bring your attention on the fact that in the `package.json`'s bin entry I've called the command `karate` which, tell me if I'm wrong, should not cause any conflict as the `karate` command is not installed with JBang. Indeed the `preinstall.js` file is just running the Karate command with no arguments via JBang, there's no `app install ...` kind of command at preinstall step. In case there's any issue with the command's name we would need to change it. Maybe we want to install Karate via JBang in this script, let's discuss what you would like here or add it in another feature.

I've also improved the documentation, but all is subject to discussion of course.

Let me know if I need to change anything.

See ya guys