### PR TITLE
Use valid jbang dep 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "author": "Peter Thomas",
   "license": "MIT",
   "dependencies": {
-    "@jbangdev/jbang": "^0.2.2"
+    "@jbangdev/jbang": "^0.2.0"
   }
 }


### PR DESCRIPTION
Jbang does not have a version >0.2.2 yet

Fixes error during `npm i`

```
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @jbangdev/jbang@^0.2.2.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```